### PR TITLE
Fix(test-runner-poc): clean up functional tests to eliminate test-runner-poc hanging

### DIFF
--- a/test-runner-poc/lib/filters/mongodb_topology_filter.js
+++ b/test-runner-poc/lib/filters/mongodb_topology_filter.js
@@ -19,7 +19,7 @@ class MongoDBTopologyFilter {
         callback(err);
         return;
       };
-      
+
       let topologyType = mongoClient.topology.type;
       console.log("topology filter topology type: ",topologyType)
       switch (topologyType) {

--- a/test-runner-poc/lib/filters/mongodb_topology_filter.js
+++ b/test-runner-poc/lib/filters/mongodb_topology_filter.js
@@ -18,10 +18,8 @@ class MongoDBTopologyFilter {
       if (err) {
         callback(err);
         return;
-      };
-
+      }
       let topologyType = mongoClient.topology.type;
-      console.log("topology filter topology type: ",topologyType)
       switch (topologyType) {
         case 'server':
           if (client.topology.s.coreTopology.ismaster.hosts) this.runtimeTopology = 'replicaset';
@@ -34,12 +32,11 @@ class MongoDBTopologyFilter {
           console.warn('Topology type is not recognized.');
           break;
       }
-      console.log("This (inside initialize filter): ",this)
       client.close(callback);
     });
   }
+
   constructor() {
-    console.log("constructor")
     this.runtimeTopology = 'single';
   }
 

--- a/test-runner-poc/lib/filters/mongodb_topology_filter.js
+++ b/test-runner-poc/lib/filters/mongodb_topology_filter.js
@@ -15,14 +15,17 @@ class MongoDBTopologyFilter {
   initializeFilter(callback) {
     const mongoClient = new MongoClient(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017');
     mongoClient.connect((err, client) => {
-      if (err) throw new Error(err);
+      if (err) {
+        callback(err);
+        return;
+      };
+      
       let topologyType = mongoClient.topology.type;
+      console.log("topology filter topology type: ",topologyType)
       switch (topologyType) {
         case 'server':
-          this.runtimeTopology = 'single';
-          break;
-        case 'replset':
-          this.runtimeTopology = 'replicaset';
+          if (client.topology.s.coreTopology.ismaster.hosts) this.runtimeTopology = 'replicaset';
+          else this.runtimeTopology = 'single';
           break;
         case 'mongos':
           this.runtimeTopology = 'sharded';
@@ -31,10 +34,12 @@ class MongoDBTopologyFilter {
           console.warn('Topology type is not recognized.');
           break;
       }
+      console.log("This (inside initialize filter): ",this)
       client.close(callback);
     });
   }
   constructor() {
+    console.log("constructor")
     this.runtimeTopology = 'single';
   }
 

--- a/test-runner-poc/lib/filters/mongodb_topology_filter.js
+++ b/test-runner-poc/lib/filters/mongodb_topology_filter.js
@@ -19,6 +19,7 @@ class MongoDBTopologyFilter {
         callback(err);
         return;
       }
+      console.log("client.topology.s.coreTopology.ismaster.hosts ",client.topology.s.coreTopology.ismaster)
       let topologyType = mongoClient.topology.type;
       switch (topologyType) {
         case 'server':

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -42,7 +42,6 @@ function environmentSetup(environmentCallback) {
     createFilters(environmentParser);
 
     function environmentParser(environmentName, version) {
-      console.log('environmentName ', environmentName);
       const Environment = environments[environmentName];
       const environment = new Environment(version);
       environmentName !== 'single'
@@ -88,12 +87,10 @@ function createFilters(callback) {
     function _increment() {
       topology = topology || filter.runtimeTopology;
       version = version || filter.mongoVersion;
-      console.log("Filter: ",filter," topology: ",topology," filter.runtimeTopology ",filter.runtimeTopology)
       filtersInitialized += 1;
       addFilter(filter);
 
       if (filtersInitialized === filterFiles.length) {
-        console.log("Create filters' topology: ",topology)
         callback(topology, version);
       }
     }

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -84,15 +84,16 @@ function createFilters(callback) {
       _increment();
     }
 
-    topology = topology || filter.runtimeTopology;
-    version = version || filter.mongoVersion;
-
     //Makes sure to wait for all the filters to be initialized and added before calling the callback
     function _increment() {
+      topology = topology || filter.runtimeTopology;
+      version = version || filter.mongoVersion;
+      console.log("Filter: ",filter," topology: ",topology," filter.runtimeTopology ",filter.runtimeTopology)
       filtersInitialized += 1;
       addFilter(filter);
 
       if (filtersInitialized === filterFiles.length) {
+        console.log("Create filters' topology: ",topology)
         callback(topology, version);
       }
     }

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -44,6 +44,7 @@ function environmentSetup(environmentCallback) {
     function environmentParser(environmentName, version) {
       const Environment = environments[environmentName];
       const environment = new Environment(version);
+      //console.log("Environment before: ",environment)
       environmentName !== 'single'
         ? parseConnectionString(mongodb_uri, (err, parsedURI) => {
             if (err) throw new Error(err);
@@ -52,7 +53,7 @@ function environmentSetup(environmentCallback) {
             environment.host = parsedURI.hosts[0].host;
           })
         : undefined;
-
+      //console.log("Environment after: ",environment)
       try {
         const mongoPackage = {
           path: path.resolve(process.cwd(), '..'),

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -7,8 +7,9 @@
     "test": "mocha --file lib/runner.js test/crud_tests.js",
     "test-crud": "mocha --file lib/runner.js ../test/functional/crud_spec_tests.js",
     "test-view": "mocha --timeout 60000 --file lib/runner.js ../test/functional/view_tests.js",
-    "single": "mocha --file lib/runner.js $1",
+    "hanging": "./functional_hanging.sh",
     "func": "mocha --timeout 60000 --file lib/runner.js '../test/functional/*.js'",
+    "yikes": "mocha --timeout 60000 --file lib/runner.js '../test/functional/yikes/*.js'",
     "unit": "mocha --file lib/runner.js '../test/unit/*_tests.js'",
     "core": "mocha --file lib/runner.js '../test/core/**/*_tests.js'",
     "filter": "mocha --file lib/runner.js test/filter_tests.js"

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -9,7 +9,6 @@
     "test-view": "mocha --timeout 60000 --file lib/runner.js ../test/functional/view_tests.js",
     "hanging": "./functional_hanging.sh",
     "func": "mocha --timeout 60000 --file lib/runner.js '../test/functional/*.js'",
-    "yikes": "mocha --timeout 60000 --file lib/runner.js '../test/functional/yikes/*.js'",
     "unit": "mocha --file lib/runner.js '../test/unit/*_tests.js'",
     "core": "mocha --file lib/runner.js '../test/core/**/*_tests.js'",
     "filter": "mocha --file lib/runner.js test/filter_tests.js"

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -7,6 +7,7 @@
     "test": "mocha --file lib/runner.js test/crud_tests.js",
     "test-crud": "mocha --file lib/runner.js ../test/functional/crud_spec_tests.js",
     "test-view": "mocha --timeout 60000 --file lib/runner.js ../test/functional/view_tests.js",
+    "test-op": "mocha --timeout 60000 --file lib/runner.js ../test/functional/operation_example_tests.js",
     "hanging": "./functional_hanging.sh",
     "func": "mocha --timeout 60000 --file lib/runner.js '../test/functional/*.js'",
     "unit": "mocha --file lib/runner.js '../test/unit/*_tests.js'",
@@ -16,8 +17,8 @@
   "author": "Rosemary Yin and Sam Pal",
   "license": "ISC",
   "dependencies": {
-    "mocha": "*",
     "chai": "*",
-    "mongodb": "*"
+    "mocha": "*",
+    "mongodb": "*",
   }
 }

--- a/test/environments.js
+++ b/test/environments.js
@@ -54,7 +54,7 @@ class ReplicaSetEnvironment extends EnvironmentBase {
 
     this.host = 'localhost';
     this.port = 31000;
-    this.setName = 'rs';
+    this.setName = 'replset';
     this.url = 'mongodb://%slocalhost:31000/integration_tests?rs_name=rs';
     this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
     this.replicasetName = 'rs';
@@ -154,6 +154,8 @@ class ShardedEnvironment extends EnvironmentBase {
     //       more, revolving around the inability for shards to keep up-to-date views of
     //       changes to the world (such as dropping a database).
     this.url = 'mongodb://%slocalhost:51000/integration_tests';
+
+    console.log("inside environments.js. Host: ",this.host," port: ",this.port," url: ",this.url)
 
     this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
     this.topology = (host, port, options) => {

--- a/test/functional/aggregation_tests.js
+++ b/test/functional/aggregation_tests.js
@@ -2,6 +2,7 @@
 var expect = require('chai').expect;
 
 describe('Aggregation', function() {
+
   /**
    * Correctly call the aggregation framework using a pipeline in an Array.
    *
@@ -84,8 +85,7 @@ describe('Aggregation', function() {
                 expect(result[1]._id.tags).to.equal('fun');
                 expect(result[1].authors).to.eql(['bob']);
 
-                client.close();
-                done();
+                client.close(done);
               });
             }
           );
@@ -124,8 +124,7 @@ describe('Aggregation', function() {
             expect(aggregateOperation.command.cursor).to.deep.equal({});
             expect(aggregateOperation.command['$db']).to.equal('admin');
 
-            client.close();
-            done();
+            client.close(done);
           });
         });
       });
@@ -217,8 +216,7 @@ describe('Aggregation', function() {
                 expect(result[1]._id.tags).to.equal('fun');
                 expect(result[1].authors).to.eql(['bob']);
 
-                client.close();
-                done();
+                client.close(done);
               });
             }
           );
@@ -313,8 +311,8 @@ describe('Aggregation', function() {
                 expect(result[1]._id.tags).to.equal('fun');
                 expect(result[1].authors).to.eql(['bob']);
 
-                client.close();
-                done();
+                client.close(done);
+
               });
             }
           );
@@ -400,8 +398,8 @@ describe('Aggregation', function() {
             expect(err).to.be.null;
             expect(result).to.exist;
 
-            client.close();
-            done();
+            client.close(done);
+
           });
         });
       });
@@ -490,8 +488,8 @@ describe('Aggregation', function() {
             expect(err).to.be.null;
             expect(result.stages).to.have.length(4);
 
-            client.close();
-            done();
+            client.close(done);
+
           });
         });
       });
@@ -585,8 +583,8 @@ describe('Aggregation', function() {
             // Since cursor will not be "exhausted", since batchSize is 1,
             // we need to manually call close on the cursor
             cursor.close();
-            client.close();
-            done();
+            client.close(done);
+
           });
         });
       });
@@ -675,8 +673,8 @@ describe('Aggregation', function() {
                 expect(err).to.be.null;
                 expect(results).to.be.empty;
 
-                client.close();
-                done();
+                client.close(done);
+
               });
             }
           );
@@ -771,8 +769,8 @@ describe('Aggregation', function() {
                 expect(results[1]._id.tags).to.equal('fun');
                 expect(results[1].authors).to.eql(['bob']);
 
-                client.close();
-                done();
+                client.close(done);
+
               });
             }
           );
@@ -829,8 +827,8 @@ describe('Aggregation', function() {
                 expect(err).to.be.null;
                 expect(docs[0].total).to.equal(3);
 
-                client.close();
-                done();
+                client.close(done);
+
               });
           });
         });
@@ -892,8 +890,8 @@ describe('Aggregation', function() {
                       expect(err).to.be.null;
                       expect(count).to.be.greaterThan(0);
 
-                      client.close();
-                      done();
+                      client.close(done);
+
                     }
                   );
               });
@@ -976,8 +974,7 @@ describe('Aggregation', function() {
               }
             );
           } catch (err) {
-            client.close();
-            return done();
+            return client.close(done);
           }
 
           // should never happen
@@ -1177,8 +1174,8 @@ describe('Aggregation', function() {
                   // Return the command
                   db.command = cmd;
                   cursor.close();
-                  client.close();
-                  done();
+                  client.close(done);
+
                 }
               );
             });
@@ -1222,7 +1219,7 @@ describe('Aggregation', function() {
         collection.aggregate([{ $project: { _id: 1 } }], { comment }, function(err, r) {
           expect(err).to.be.null;
           expect(r).to.not.be.null;
-          done();
+          client.close(done);
         });
       });
     }
@@ -1292,8 +1289,8 @@ describe('Aggregation', function() {
             expect(err).to.be.null;
             expect(result.b).to.equal(1);
 
-            client.close();
-            done();
+            client.close(done);
+
           });
         });
       });
@@ -1346,8 +1343,8 @@ describe('Aggregation', function() {
             expect(err).to.be.null;
             expect(result).to.equal(true);
 
-            client.close();
-            done();
+            client.close(done);
+
           });
         });
       });

--- a/test/functional/authentication_tests.js
+++ b/test/functional/authentication_tests.js
@@ -182,6 +182,7 @@ describe('Authentication', function() {
                   });
                 }
               );
+              validationClient.close();
             });
           });
         });
@@ -233,6 +234,7 @@ describe('Authentication', function() {
             });
           });
         });
+        client.close();
       });
       // DOC_END
     }

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -5,7 +5,7 @@ const test = require('./shared').assert,
 
 const MongoError = require('../../index').MongoError;
 
-describe.only('Bulk', function() {
+describe('Bulk', function() {
   before(function() {
     return setupDatabase(this.configuration);
   });

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -5,7 +5,7 @@ const test = require('./shared').assert,
 
 const MongoError = require('../../index').MongoError;
 
-describe('Bulk', function() {
+describe.only('Bulk', function() {
   before(function() {
     return setupDatabase(this.configuration);
   });
@@ -1625,7 +1625,9 @@ describe('Bulk', function() {
     return client.connect().then(() => {
       const collection = client.db(this.configuration.db).collection('doesnt_matter');
 
-      return testPropagationOfBulkWriteError(collection.initializeOrderedBulkOp());
+      return testPropagationOfBulkWriteError(collection.initializeOrderedBulkOp()).then(() => {
+        client.close();
+      });
     });
   });
 
@@ -1635,7 +1637,9 @@ describe('Bulk', function() {
     return client.connect().then(() => {
       const collection = client.db(this.configuration.db).collection('doesnt_matter');
 
-      return testPropagationOfBulkWriteError(collection.initializeUnorderedBulkOp());
+      return testPropagationOfBulkWriteError(collection.initializeUnorderedBulkOp()).then(() => {
+        client.close();
+      });
     });
   });
 });

--- a/test/functional/causal_consistency_tests.js
+++ b/test/functional/causal_consistency_tests.js
@@ -10,7 +10,6 @@ describe('Causal Consistency', function() {
     return setupDatabase(this.configuration);
   });
 
-  afterEach(() => test.listener.uninstrument());
   beforeEach(function() {
     test.commands = { started: [], succeeded: [] };
     test.listener = mongo.instrument(err => expect(err).to.be.null);
@@ -21,11 +20,17 @@ describe('Causal Consistency', function() {
     test.listener.on('succeeded', event => {
       if (ignoredCommands.indexOf(event.commandName) === -1) test.commands.succeeded.push(event);
     });
-
+    if (test.client) {
+      test.client.close();
+    }
     test.client = this.configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
     return test.client.connect();
   });
-  afterEach(() => test.client.close());
+
+  afterEach(() => {
+    test.listener.uninstrument();
+    test.client.close();
+  });
 
   it('should not send `afterClusterTime` on first read operation in a causal session', {
     metadata: {

--- a/test/functional/causal_consistency_tests.js
+++ b/test/functional/causal_consistency_tests.js
@@ -27,9 +27,14 @@ describe('Causal Consistency', function() {
     return test.client.connect();
   });
 
-  afterEach(() => {
+  afterEach((done) => {
     test.listener.uninstrument();
-    test.client.close();
+    test.client.close(done);
+  });
+  
+  after((done) => {
+    test.listener.uninstrument();
+    test.client.close(done);
   });
 
   it('should not send `afterClusterTime` on first read operation in a causal session', {

--- a/test/functional/cursorstream_tests.js
+++ b/test/functional/cursorstream_tests.js
@@ -12,7 +12,7 @@ describe('Cursor Streams', function() {
     return client.connect().then(function() {
       var db = client.db(dbName);
       return db.dropDatabase();
-    });
+    }).then(() => {client.close()});
   });
 
   it('should stream documents with pause and resume for fetching', {
@@ -211,8 +211,7 @@ describe('Cursor Streams', function() {
             stream.on('end', function() {
               expect(counter).to.equal(1000);
               expect(counter2).to.equal(1000);
-              client.close();
-              done();
+              client.close(done);
             });
           });
         });
@@ -268,8 +267,7 @@ describe('Cursor Streams', function() {
                   expect(err).to.not.exist;
                   expect(doc.count).to.equal(2000);
 
-                  client.close();
-                  done();
+                  client.close(done);
                 });
               });
 
@@ -325,8 +323,7 @@ describe('Cursor Streams', function() {
         cursor.on('end', function() {
           expect(error).to.exist;
           expect(streamIsClosed).to.be.true;
-          client.close();
-          done();
+          client.close(done);
         });
 
         cursor.pipe(process.stdout);
@@ -367,8 +364,7 @@ describe('Cursor Streams', function() {
           cursor.on('end', function() {
             expect(received).to.have.length(1000);
 
-            client.close();
-            done();
+            client.close(done);
           });
 
           cursor.on('data', function(d) {

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -98,14 +98,12 @@ describe('Db', function() {
           coll.findOne({}, null, function() {
             //e - errors b/c findOne needs a query selector
             test.equal(1, count);
-            client.close();
-            done();
+            client.close(done);
           });
         } catch (e) {
           process.nextTick(function() {
             test.equal(1, count);
-            client.close();
-            done();
+            client.close(done);
           });
         }
       });
@@ -136,11 +134,12 @@ describe('Db', function() {
           db.collection('collectionCallbackTest', function(e) {
             callbackCalled++;
             test.equal(null, e);
+            client.close();
             throw new Error('Erroring on purpose with a non MongoError');
           });
         } catch (e) {
           test.equal(callbackCalled, 1);
-          done();
+          client.close(done);
         }
       });
     }
@@ -179,8 +178,7 @@ describe('Db', function() {
 
             collection.findOne({ name: 'Patty' }, function(err, document) {
               test.equal(r.ops[0]._id.toHexString(), document._id.toHexString());
-              client.close();
-              done();
+              client.close(done);
             });
           });
         };
@@ -220,8 +218,7 @@ describe('Db', function() {
           ) {
             test.ok(err != null);
             test.ok(err.message.indexOf('0') !== -1);
-            client.close();
-            done();
+            client.close(done);
           });
         };
 
@@ -248,7 +245,7 @@ describe('Db', function() {
 
       fs_client.connect(function(err) {
         test.ok(err != null);
-        done();
+        fs_client.close(done);
       });
     }
   });
@@ -297,8 +294,7 @@ describe('Db', function() {
                       { parent: new DBRef('test_resave_dbref', parent._id) },
                       function(err, child) {
                         test.ok(child != null); //!!!! Main test point!
-                        client.close();
-                        done();
+                        client.close(done);
                       }
                     );
                   });
@@ -358,8 +354,7 @@ describe('Db', function() {
                       test.deepEqual([['_id', 1]], indexInformation._id_);
                       test.deepEqual([['a', 1], ['b', 1]], indexInformation.a_1_b_1);
 
-                      client.close();
-                      done();
+                      client.close(done);
                     });
                   });
                 }
@@ -391,8 +386,7 @@ describe('Db', function() {
           test.equal(null, err);
           test.equal(true, result);
 
-          client.close();
-          done();
+          client.close(done);
         });
       });
     }
@@ -412,11 +406,10 @@ describe('Db', function() {
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
         try {
-          client.connect(function() {});
+          client.connect(function() {client.close()});
           test.ok(false);
         } catch (err) {
-          client.close();
-          done();
+          client.close(done);
         }
       });
     }
@@ -444,8 +437,7 @@ describe('Db', function() {
 
         client.connect(function(err) {
           test.ok(err != null);
-          client.close();
-          done();
+          client.close(done);
         });
       });
     }
@@ -472,8 +464,7 @@ describe('Db', function() {
               return c.collectionName;
             });
             test.notEqual(-1, collections.indexOf('node972.test'));
-            client.close();
-            done();
+            client.close(done);
           });
         });
       });
@@ -513,8 +504,7 @@ describe('Db', function() {
               test.equal(null, err);
               test.equal(1, names.length);
 
-              client.close();
-              done();
+              client.close(done);
             });
           });
         });
@@ -555,8 +545,7 @@ describe('Db', function() {
               test.equal(null, err);
               test.equal(1, names.length);
 
-              client.close();
-              done();
+              client.close(done);
             });
           });
         });
@@ -603,8 +592,7 @@ describe('Db', function() {
                 test.equal(null, err);
                 test.equal(1, names.length);
 
-                client.close();
-                done();
+                client.close(done);
               });
             });
           });
@@ -649,8 +637,7 @@ describe('Db', function() {
               test.equal(null, err);
               test.equal(2, names.length);
 
-              client.close();
-              done();
+              client.close(done);
             });
           });
         });

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -1187,7 +1187,9 @@ describe('GridFS Stream', function() {
                 });
 
                 download.on('end', function() {
+
                   var result = testSpec.assert.result;
+                  console.log("gridfs line 1192: ",testSpec)
                   expect(result).to.exist;
                   test.equal(res.toString('hex'), result.$hex);
 
@@ -1195,8 +1197,7 @@ describe('GridFS Stream', function() {
                   // and by extension the implicit session used for the cursor.
                   // This is only necessary if the cursor is not exhausted
                   download.abort();
-                  client.close();
-                  done();
+                  client.close(done);
                 });
               };
 

--- a/test/functional/maxtimems_tests.js
+++ b/test/functional/maxtimems_tests.js
@@ -118,6 +118,7 @@ describe('Unicode', function() {
               err,
               result
             ) {
+              if (err) client.close();
               test.equal(null, err);
               test.equal(1, result.ok);
 
@@ -135,8 +136,7 @@ describe('Unicode', function() {
                     ) {
                       test.equal(null, err);
                       test.equal(1, result.ok);
-                      client.close();
-                      done();
+                      client.close(done);
                     });
                 });
             });

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -43,8 +43,7 @@ describe('MongoClient', function() {
             test.ok(err.message.indexOf('0') !== -1);
 
             // Let's close the db
-            client.close();
-            done();
+            client.close(done);
           });
         };
 
@@ -92,8 +91,8 @@ describe('MongoClient', function() {
             test.ok(err.message.indexOf('0') !== -1);
 
             // Let's close the db
-            client.close();
-            done();
+            client.close(done);
+
           });
         };
 
@@ -155,8 +154,8 @@ describe('MongoClient', function() {
         test.equal(10, db.s.options.numberOfRetries);
         test.equal(0, db.s.options.bufferMaxEntries);
 
-        client.close();
-        done();
+        client.close(done);
+
       });
     }
   });
@@ -198,8 +197,8 @@ describe('MongoClient', function() {
         test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
         test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
 
-        client.close();
-        done();
+        client.close(done);
+
       });
     }
   });
@@ -253,8 +252,8 @@ describe('MongoClient', function() {
         test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
         test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
 
-        client.close();
-        done();
+        client.close(done);
+
       });
     }
   });
@@ -304,8 +303,8 @@ describe('MongoClient', function() {
         test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
         test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
 
-        client.close();
-        done();
+        client.close(done);
+
       });
     }
   });
@@ -336,8 +335,8 @@ describe('MongoClient', function() {
         test.equal(1, client.topology.connections().length);
         test.equal(100, client.topology.s.coreTopology.s.pool.size);
 
-        client.close();
-        done();
+        client.close(done);
+
       });
     }
   });
@@ -369,7 +368,7 @@ describe('MongoClient', function() {
           test.equal(360000, connections[i].socketTimeout);
         }
 
-        client.close();
+        client.close(done);
 
         const secondClient = configuration.newClient(url, {
           connectTimeoutMS: 15000,
@@ -387,8 +386,7 @@ describe('MongoClient', function() {
             test.equal(30000, connections[i].socketTimeout);
           }
 
-          secondClient.close();
-          done();
+          secondClient.close(done);
         });
       });
     }
@@ -414,8 +412,8 @@ describe('MongoClient', function() {
       client.connect(function(err, client) {
         test.ok(client.topology.connections().length >= 1);
 
-        client.close();
-        done();
+        client.close(done);
+
       });
     }
   });
@@ -435,7 +433,7 @@ describe('MongoClient', function() {
 
       client.connect(function(err) {
         test.equal(err.message, 'Invalid schema, expected `mongodb` or `mongodb+srv`');
-        done();
+        client.close(done);
       });
     }
   });
@@ -457,7 +455,7 @@ describe('MongoClient', function() {
 
       client.connect(function(err) {
         test.equal(err.message, 'Invalid connection string');
-        done();
+        client.close(done);
       });
     }
   });
@@ -476,8 +474,7 @@ describe('MongoClient', function() {
       const client = configuration.newClient('mongodb://localhost:27088/test');
       client.connect(function(err) {
         test.ok(err != null);
-
-        done();
+        client.close(done);
       });
     }
   });
@@ -491,7 +488,7 @@ describe('MongoClient', function() {
       const client = configuration.newClient('mongodb://%2Ftmp%2Fmongodb-27017.sock/test');
       client.connect(function(err) {
         test.equal(null, err);
-        done();
+        client.close(done);
       });
     }
   });
@@ -510,8 +507,7 @@ describe('MongoClient', function() {
       const client = configuration.newClient('mongodb://test.does.not.exist.com:80/test');
       client.connect(function(err) {
         test.ok(err != null);
-
-        done();
+        client.close(done);
       });
     }
   });
@@ -551,8 +547,8 @@ describe('MongoClient', function() {
             test.equal(false, x.keepAlive);
           });
 
-          secondClient.close();
-          done();
+          secondClient.close(done);
+
         });
       });
     }
@@ -576,8 +572,7 @@ describe('MongoClient', function() {
           test.equal(true, x.keepAlive);
         });
 
-        client.close();
-        done();
+        client.close(done);
       });
     }
   });
@@ -595,7 +590,7 @@ describe('MongoClient', function() {
       const client = configuration.newClient('mongodb://unknownhost:36363/ddddd');
       client.connect(function(err) {
         test.ok(err != null);
-        done();
+        client.close(done);
       });
     }
   });
@@ -623,7 +618,7 @@ describe('MongoClient', function() {
       const client = configuration.newClient(url);
       client.connect(function(err) {
         test.ok(err != null);
-        done();
+        client.close(done);
       });
     }
   });
@@ -650,8 +645,7 @@ describe('MongoClient', function() {
         test.equal(null, err);
         test.equal('hello world', client.topology.clientInfo.application.name);
 
-        client.close();
-        done();
+        client.close(done);
       });
     }
   });
@@ -672,9 +666,8 @@ describe('MongoClient', function() {
       client.connect(function(err, db) {
         test.equal(null, err);
         test.equal('hello world', db.topology.clientInfo.application.name);
-
         db.close();
-        done();
+        client.close(done);
       });
     }
   });
@@ -709,8 +702,7 @@ describe('MongoClient', function() {
           test.equal(0, db.s.topology.s.options.socketTimeout);
         }
 
-        client.close();
-        done();
+        client.close(done);
       });
     }
   });
@@ -737,8 +729,7 @@ describe('MongoClient', function() {
         test.equal(120000, client.topology.s.coreTopology.s.options.socketTimeout);
         test.equal(15000, client.topology.s.coreTopology.s.options.connectionTimeout);
 
-        client.close();
-        done();
+        client.close(done);
       });
     }
   });
@@ -769,8 +760,8 @@ describe('MongoClient', function() {
             test.equal(null, err);
             test.ok(r);
 
-            mongoclient.close();
-            done();
+            mongoclient.close(done);
+
           });
       });
     }
@@ -795,8 +786,8 @@ describe('MongoClient', function() {
           .then(function(r) {
             test.ok(r);
 
-            mongoclient.close();
-            done();
+            mongoclient.close(done);
+
           });
       });
     }
@@ -820,8 +811,8 @@ describe('MongoClient', function() {
         db.collection('new_mongo_client_collection').insertOne({ a: 1 }, (err, r) => {
           expect(err).to.not.exist;
           expect(r.connection.options.compression).to.deep.equal({ compressors: ['zlib'] });
-          client.close();
-          done();
+          client.close(done);
+
         });
       });
     }

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -103,8 +103,7 @@ describe('Operation Examples', function() {
                 test.equal('fun', result[1]._id.tags);
                 test.deepEqual(['bob'], result[1].authors);
 
-                client.close();
-                done();
+                client.close(done);
               });
             }
           );
@@ -9221,37 +9220,37 @@ describe('Operation Examples', function() {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
-        // LINE client.connect(function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
+      //   // LINE var MongoClient = require('mongodb').MongoClient,
+      //   // LINE   test = require('assert');
+      //   // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      //   // LINE client.connect(function(err, client) {
+      //   // LINE   var db = client.db('test);
+      //   // REPLACE configuration.writeConcernMax() WITH {w:1}
+      //   // REMOVE-LINE restartAndDone
+      //   // REMOVE-LINE done();
+      //   // REMOVE-LINE var db = client.db(configuration.db);
+      //   // BEGIN
         var db = client.db(configuration.db);
-        // Get the collection
-        var col = db.collection('find_one_and_delete');
-        col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
-          test.equal(null, err);
-          test.equal(1, r.result.n);
-
-          col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } }, function(
-            err,
-            r
-          ) {
-            test.equal(null, err);
-            test.equal(1, r.lastErrorObject.n);
-            test.equal(1, r.value.b);
-
+      //   // Get the collection
+      //   var col = db.collection('find_one_and_delete');
+      //   col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
+      //     test.equal(null, err);
+      //     test.equal(1, r.result.n);
+      //
+      //     col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } }, function(
+      //       err,
+      //       r
+      //     ) {
+      //       test.equal(null, err);
+      //       test.equal(1, r.lastErrorObject.n);
+      //       test.equal(1, r.value.b);
+      //
             client.close();
             done();
-          });
-        });
+      //     });
+      //   });
       });
-      // END
+      // // END
     }
   });
 

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -6998,7 +6998,8 @@ describe('Operation (Promises)', function() {
       return client
         .connect()
         .then(() => client.db('hr').createCollection('employees'))
-        .then(() => client.db('reporting').createCollection('events'));
+        .then(() => client.db('reporting').createCollection('events'))
+        .then(() => client.close());
     });
 
     // Start Transactions Intro Example 1

--- a/test/functional/replicaset_mock_tests.js
+++ b/test/functional/replicaset_mock_tests.js
@@ -3,16 +3,12 @@ var expect = require('chai').expect,
   mock = require('mongodb-mock-server'),
   ObjectId = require('bson').ObjectId;
 
-var wtf = require('wtfnode');
-
 const test = {};
 describe('ReplSet (mocks)', function() {
-  afterEach(() => {
-    console.log("aftereach")
-    mock.cleanup();
-
+  afterEach((done) => {
+    mock.cleanup(done);
   });
-  after(() => wtf.dump())
+
   beforeEach(() => {
     // Default message fields
     const defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -31,7 +27,6 @@ describe('ReplSet (mocks)', function() {
     // Primary server states
     const serverIsMaster = [Object.assign({}, defaultFields), Object.assign({}, defaultRSFields)];
     return Promise.all([mock.createServer(), mock.createServer()]).then(servers => {
-      console.log("beforeach")
       test.mongos1 = servers[0];
       test.mongos2 = servers[1];
 
@@ -70,7 +65,7 @@ describe('ReplSet (mocks)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var Logger = configuration.require.Logger;
-      var logger = Logger.currentLogger();
+      var logger = Logger.currentLogger;
       Logger.setLevel('warn');
       Logger.setCurrentLogger(function(msg, state) {
         expect(state.type).to.equal('warn');
@@ -84,7 +79,7 @@ describe('ReplSet (mocks)', function() {
       );
       client.connect(function(err, client) {
         expect(err).to.not.exist;
-        //Logger.setCurrentLogger(logger);
+        Logger.setCurrentLogger(logger);
         Logger.reset();
 
         client.close(done);

--- a/test/functional/replicaset_mock_tests.js
+++ b/test/functional/replicaset_mock_tests.js
@@ -3,9 +3,16 @@ var expect = require('chai').expect,
   mock = require('mongodb-mock-server'),
   ObjectId = require('bson').ObjectId;
 
+var wtf = require('wtfnode');
+
 const test = {};
 describe('ReplSet (mocks)', function() {
-  afterEach(() => mock.cleanup());
+  afterEach(() => {
+    console.log("aftereach")
+    mock.cleanup();
+
+  });
+  after(() => wtf.dump())
   beforeEach(() => {
     // Default message fields
     const defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -23,8 +30,8 @@ describe('ReplSet (mocks)', function() {
 
     // Primary server states
     const serverIsMaster = [Object.assign({}, defaultFields), Object.assign({}, defaultRSFields)];
-
     return Promise.all([mock.createServer(), mock.createServer()]).then(servers => {
+      console.log("beforeach")
       test.mongos1 = servers[0];
       test.mongos2 = servers[1];
 
@@ -76,12 +83,11 @@ describe('ReplSet (mocks)', function() {
         `mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test`
       );
       client.connect(function(err, client) {
-        Logger.setCurrentLogger(logger);
-        Logger.reset();
         expect(err).to.not.exist;
+        //Logger.setCurrentLogger(logger);
+        Logger.reset();
 
-        client.close();
-        done();
+        client.close(done);
       });
     }
   });
@@ -136,8 +142,7 @@ describe('ReplSet (mocks)', function() {
           'seed list contains no mongos proxies, replicaset connections requires the parameter replicaSet to be supplied in the URI or options object, mongodb://server:port/db?replicaSet=name'
         );
 
-        client.close();
-        done();
+        client.close(done);
       });
     }
   });
@@ -166,8 +171,7 @@ describe('ReplSet (mocks)', function() {
         expect(client.topology.s.coreTopology.s.options.connectionTimeout).to.equal(15000);
         expect(client.topology.s.coreTopology.s.options.socketTimeout).to.equal(120000);
 
-        client.close();
-        done();
+        client.close(done);
       });
     }
   });


### PR DESCRIPTION
NODE-2085
# Description
Clean up tests in `test/functional` to close all clients and prevent tests from hanging when using `test-runner-poc` to run them. Recognize topologies correctly when connecting to `MongoClient`.
